### PR TITLE
Tweet本文のフォント設定と背景色設定を使用する close #2

### DIFF
--- a/message_detail_view.rb
+++ b/message_detail_view.rb
@@ -68,11 +68,15 @@ Plugin.create(:message_detail_view) do
     Gtk::CssProvider.new.tap do |provider|
       provider.load_from_data(<<~CSS)
         *, *:active, *:disabled, *:hover, *:focus {
-          color: rgb(#{fgcolor[0] / 256}, #{fgcolor[1] / 256}, #{fgcolor[2] / 256});
-          background-color: rgb(#{bgcolor[0] / 256}, #{bgcolor[1] / 256}, #{bgcolor[2] / 256});
+          color: #{css_rgb(fgcolor)};
+          background-color: #{css_rgb(bgcolor)};
         }
       CSS
     end
+  end
+
+  def css_rgb(uccolor)
+    sprintf('#%02x%02x%02x', *uccolor.map { _1 >> 8 & 0xff })
   end
 
 end

--- a/message_detail_view.rb
+++ b/message_detail_view.rb
@@ -51,7 +51,7 @@ Plugin.create(:message_detail_view) do
   message_fragment :body, "body" do
     set_icon Skin[:message]
     container = Gtk::Box.new(:horizontal)
-    textview = Gtk::IntelligentTextview.new(model.description, { 'font' => :mumble_basic_font })
+    textview = Gtk::IntelligentTextview.new(model.description, { 'font' => :twitter_tweet_basic_font })
     textview.hexpand = true
     textview.style_generator = get_style_provider
     textview.bg_modifier
@@ -63,11 +63,13 @@ Plugin.create(:message_detail_view) do
   end
 
   def get_style_provider
-    color = UserConfig[:mumble_basic_bg]
+    fgcolor = UserConfig[:twitter_tweet_basic_color]
+    bgcolor = UserConfig[:twitter_tweet_basic_bg]
     Gtk::CssProvider.new.tap do |provider|
       provider.load_from_data(<<~CSS)
         *, *:active, *:disabled, *:hover, *:focus {
-          background-color: rgb(#{color[0] / 256}, #{color[1] / 256}, #{color[2] / 256});
+          color: rgb(#{fgcolor[0] / 256}, #{fgcolor[1] / 256}, #{fgcolor[2] / 256});
+          background-color: rgb(#{bgcolor[0] / 256}, #{bgcolor[1] / 256}, #{bgcolor[2] / 256});
         }
       CSS
     end


### PR DESCRIPTION
#2 の修正案です。
mikutter 本体側の core/mui/gtk_intelligent_textview.rb 側で
フォントと色の扱いを CSSで統一する仕組みが必要という気もしますが、
とりあえず雑対処で現状背景用で用意されている `style_provider` で
背景色とともにフォントの文字色も設定しています。